### PR TITLE
update scikit-learn to stable release

### DIFF
--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -8,7 +8,7 @@ simplejson==3.16.0
 Werkzeug==0.15.2
 numpy==1.16.4
 pandas==0.24.2
-scikit-learn==0.19.1
+scikit-learn==0.21.2
 scipy==1.0.0
 requests==2.22.0
 gunicorn==19.9.0


### PR DESCRIPTION
in Docker container receiving:
`UserWarning: Trying to unpickle estimator RandomForestRegressor from version 0.21.2 when using version 0.19.1. This might lead to breaking code or invalid results. Use at your own risk.
  UserWarning)
[2019-06-29 19:35:38,230] ERROR in app: Exception on /api [GET]`